### PR TITLE
Change rehydrateState from bool to string[].

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const createLocalStorageMiddleware = (keys : string[]) => {
     }
 };
 
-export const localStorageMiddleware = (keys : string[], rehydrateState : boolean = false) => {
+export const localStorageMiddleware = (keys : string[], rehydrateState : string[]) => {
     const middleware = createLocalStorageMiddleware(keys);
     const localStorageProvider = provide(POST_MIDDLEWARE, {
         multi: true,
@@ -48,6 +48,10 @@ export const localStorageMiddleware = (keys : string[], rehydrateState : boolean
     });
 
     return rehydrateState
-        ? [localStorageProvider, rehydrateApplicationState(keys)]
+        ? [localStorageProvider, rehydrateApplicationState(
+            rehydrateState.filter(state => {
+                return keys.filter(key => key === state).length > 0;
+            })
+        )]
         : [localStorageProvider]
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,10 +48,22 @@ export const localStorageMiddleware = (keys : string[], rehydrateState : string[
     });
 
     return rehydrateState
-        ? [localStorageProvider, rehydrateApplicationState(
-            rehydrateState.filter(state => {
-                return keys.filter(key => key === state).length > 0;
-            })
-        )]
+        ? [localStorageProvider, keyCheck(keys, rehydrateState)]
         : [localStorageProvider]
+};
+
+const keyCheck = (keys, rehydrateState) => {
+    const result = rehydrateState.filter(state => {
+        return keys.filter(key => key === state).length > 0;
+    });
+    
+    if (result.length === rehydrateState.length) {        
+        rehydrateApplicationState(result);
+    } else {
+        const failedKey = rehydrateState.filter(state => {
+            return !(keys.filter(key => key === state).length > 0);
+        });
+        console.log("The following keys are erroneous:");
+        console.log(failedKey);
+    }
 };


### PR DESCRIPTION
The current method, localStorageMiddleware(), takes in two parameter, string[] and Boolean.
The user can pass in a Boolean value into the second parameter to rehydrate all or none of the keys.

This change will allow the user to pass in a string[] into the second parameter to indicate which keys to rehydrate and verifies it against the existing keys.

Will add console.log later to indicate which key(s) the user passed in had failed.