### PR TITLE
Added support for partial state sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Simple syncing between ngrx store and local storage
 npm install ngrx-store-localstorage --save
 ```
 1. Import `compose` and `combineReducers` from `@ngrx/store` and `@ngrx/core/compose`
-2. Invoke the `localStorageSync` function after `combineReducers`, specifying the slices of state you would like to keep synced with local storage. 
+2. Invoke the `localStorageSync` function after `combineReducers`, specifying the slices of state you would like to keep synced with local storage.
 3. Optionally specify whether to rehydrate this state from local storage as `initialState` on application bootstrap.
-4. Invoke composed function with application reducers as an argument to `provideStore`. 
+4. Invoke composed function with application reducers as an argument to `provideStore`.
 
 ```ts
 import {bootstrap} from '@angular/platform-browser-dynamic';
@@ -36,10 +36,14 @@ document.addEventListener('DOMContentLoaded', main);
 ```
 
 ## API
-### `localStorageSync(keys : string[], rehydrateState : boolean = false) : Reducer`
+### `localStorageSync(keys : any[], rehydrateState : boolean = false) : Reducer`
 Provide state (reducer) keys to sync with local storage. Optionally specify whether to rehydrate `initialState` from local storage on bootstrap.
 *Returns a meta-reducer*
 
 #### Arguments
-* `keys` \(*string[]*): State keys to sync with local storage
+* `keys` State keys to sync with local storage. The keys can be defined in two different formats:
+    * \(*string[]*): array of strings representing the state (reducer) keys. Full state will be synced (e.g. `localStorageSync(['todos'])`).
+
+    * \(*object[]*): Array of objects where for each object the key represents the state key and the value represents an array of properties which should be synced. This allows for the partial state sync (e.g. `localStorageSync([{todos: ['name', 'status'] }, ... ])`)
+
 * `rehydrateState` \(*boolean? = false*): Pull initial state from local storage on startup

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@ngrx/store": "^2.0.0"
   },
   "devDependencies": {
-    "@angular/core": "2.0.0-rc.3",
+    "@angular/core": "^2.0.0-rc.1",
     "@ngrx/core": "^1.0.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.13",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "tslint": "^3.4.0",
     "typescript": "^1.7.3",
     "typings": "^0.6.6",
-    "zone.js": "0.5.15",
+    "zone.js": "^0.6.6",
     "@ngrx/store": "^2.0.0",
-    "rxjs": "^5.0.0-beta.6"
+    "rxjs": "5.0.0-beta.6"
   },
   "typings": "./dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   "homepage": "https://github.com/btroncone/ngrx-store-localstorage#readme",
   "peerDependencies": {
     "rxjs": "^5.0.0-beta.6",
-    "@angular/core": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.3",
     "@ngrx/store": "^2.0.0"
   },
   "devDependencies": {
-    "@angular/core": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.3",
     "@ngrx/core": "^1.0.0",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.13",

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const syncStateUpdate = (state : any, keys : string[]) => {
           stateSlice = state[name];
 
           if (key[name]) {
-            stateSlice = key[name].map(function (memo, attr) {
+            stateSlice = key[name].reduce(function (memo, attr) {
               memo[attr] = stateSlice[attr];
               return memo;
             }, {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,9 @@ const validateStateKeys = (keys: any[]) => {
 
 const rehydrateApplicationState = (keys: string[]) => {
     return keys.reduce((acc, curr) => {
+        if (typeof curr == 'object') {
+          curr = Object.keys(curr)[0];
+        }
         let stateSlice = localStorage.getItem(curr);
         if(stateSlice){
             return Object.assign({}, acc, { [curr]: parseWithDates(stateSlice) })
@@ -49,11 +52,10 @@ const syncStateUpdate = (state : any, keys : string[]) => {
           stateSlice = state[name];
 
           if (key[name]) {
-            stateSlice = key[name].map(function (attr) {
-              let obj = {};
-              obj[attr] = stateSlice[attr];
-              return obj;
-            });
+            stateSlice = key[name].map(function (memo, attr) {
+              memo[attr] = stateSlice[attr];
+              return memo;
+            }, {});
           }
 
           key = name;

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const syncStateUpdate = (state : any, keys : string[]) => {
           stateSlice = state[name];
 
           if (key[name]) {
-            stateSlice = key[name].reduce(function (memo, attr) {
+            stateSlice = key[name].reduce((memo, attr) => {
               memo[attr] = stateSlice[attr];
               return memo;
             }, {});


### PR DESCRIPTION
@btroncone it looks like you are already working on v2 and perhaps you had this already outlined but I really needed to support a partial state sync. I think this is similar to #4. This pull request introduces a new way of defining keys in a form of:

````js 
localStorageSync([{todos: ['name', 'status'] }, ... ])
````
where the key represents the state key and the value represents an array of properties which should be synced.

The previous format:

````js 
localStorageSync('todos', ... ])
````
should be still supported.

