### PR TITLE
use Date.parse instead of RegEx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 const INIT_ACTION = '@ngrx/store/init';
-const detectDate = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
 // correctly parse dates from local storage
 export const dateReviver = (key: string, value: any) => {
-    if (typeof value === 'string' && (detectDate.test(value))) {
+    if (typeof value === 'string' && (Date.parse(value))) {
         return new Date(value);
     }
     return value;


### PR DESCRIPTION
Hello!

Thanks for the nice module, I do use this on daily basis :)
I realised a behiviour and realised that the RegEx to test the date string is not enough. Here is a way to reproduce it:
```js
const detectDate = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
detectDate.test('foo1111-11-11T11:11:11bar')
```

`Date.parse` could be used as a validator so I replaced that with it.

Cheers!