### PR TITLE
Update readme for ngrx store 4.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install ngrx-store-localstorage --save
 ```ts
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { StoreModule, ActionReducerMap, ActionReducer } from '@ngrx/store';
+import { StoreModule, ActionReducerMap, ActionReducer, MetaReducer } from '@ngrx/store';
 import { localStorageSync } from 'ngrx-store-localstorage';
 import { reducers } from './reducers';
 
@@ -25,7 +25,7 @@ const reducers: ActionReducerMap<IState> = {todos, visibilityFilter};
 export function localStorageSyncReducer(reducer: ActionReducer<any>): ActionReducer<any> {
   return localStorageSync({keys: ['todos']})(reducer);
 }
-const metaReducers: Array<ActionReducer<any, any>> = [localStorageSyncReducer];
+const metaReducers: Array<MetaReducer<any, any>> = [localStorageSyncReducer];
 
 @NgModule({
   imports: [


### PR DESCRIPTION
ngrx/platform#270 (landed in store 4.0.3) changed the type signature of the meta reducers array.
This fixes the resulting type conflict with the usage example.