### PR TITLE
Evaluating if the persisted state is an object

### DIFF
--- a/spec/index_spec.ts
+++ b/spec/index_spec.ts
@@ -106,6 +106,9 @@ describe('ngrxLocalStorage', () => {
 
     let undefinedStateJson = JSON.stringify(undefinedState);
 
+    const primitiveStr = 'string is not an object';
+    const initialStatePrimitiveStr = { state: primitiveStr };
+
     it('simple', () => {
         // This tests a very simple state object syncing to mock Storage
         // Since we're not specifiying anything for rehydration, the roundtrip
@@ -124,6 +127,19 @@ describe('ngrxLocalStorage', () => {
 
         expect(t1 instanceof TypeA).toBeTruthy();
         expect(finalState.simple instanceof TypeA).toBeFalsy();
+    });
+
+    it('simple string', () => {
+        const s = new MockStorage();
+        const skr = mockStorageKeySerializer;
+
+        syncStateUpdate(initialStatePrimitiveStr, ['state'], s, skr, false);
+
+        const raw = s.getItem('state');
+        expect(raw).toEqual(primitiveStr);
+
+        const finalState: any = rehydrateApplicationState(['state'], s, skr);
+        expect(finalState.state).toEqual(primitiveStr);
     });
 
     it('filtered', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,14 @@ export const rehydrateApplicationState = (keys: any[], storage: Storage, storage
             if (decrypt) {
                 stateSlice = decrypt(stateSlice);
             }
-            let raw = JSON.parse(stateSlice, reviver);
+
+            const isObjectRegex = new RegExp('\{|\\[');
+            let raw = stateSlice;
+
+            if (isObjectRegex.exec(stateSlice)) {
+                raw = JSON.parse(stateSlice, reviver);
+            }
+
             return Object.assign({}, acc, { [key]: deserialize ? deserialize(raw) : raw });
         }
         return acc;

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export const rehydrateApplicationState = (keys: any[], storage: Storage, storage
             const isObjectRegex = new RegExp('\{|\\[');
             let raw = stateSlice;
 
-            if (isObjectRegex.exec(stateSlice)) {
+            if (isObjectRegex.test(stateSlice.charAt(0))) {
                 raw = JSON.parse(stateSlice, reviver);
             }
 


### PR DESCRIPTION
This fixes the issue #58 .
The state presented on the report is a string instead of an object thus JSON.parse throws an exception.