### PR TITLE
Fix Typo. Add Storage Interface Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ An interface defining the configuration attributes to bootstrap `localStorageSyn
 
             * reviver: A reviver function as specified in the [JSON.parse documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
-            * filter: An array of properties which should be synced (same format as the stand-along array specified above).
+            * filter: An array of properties which should be synced (same format as the stand-alone array specified above).
 
 * `rehydrate` (optional) `boolean`: Pull initial state from local storage on startup, this will default to `false`.
-* `storage` (optional) `Storage`: Specify an object that conforms to the Storage interface to use, this will default to `localStorage`.
+* `storage` (optional) `Storage`: Specify an object that conforms to the [Storage interface](https://github.com/Microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L9708) to use, this will default to `localStorage`.
 * `removeOnUndefined` (optional) `boolean`: Specify if the state is removed from the storage when the new value is undefined, this will default to `false`.
 * `storageKeySerializer` (optional) `(key: string) => string`: Сustom serialize function for storage keys, used to avoid Storage conflicts. 
 Usage: `localStorageSync({keys: ['todos', 'visibilityFilter'], storageKeySerializer: (key) => 'cool_' + key, ... })`. In this example `Storage` will use keys `cool_todos` and `cool_visibilityFilter` keys to store `todos` and `visibilityFilter` slices of state). The key itself is used by default - `(key) => key`.


### PR DESCRIPTION
There was a tiny typo in the docs for the `filter` option. I also added a link to lib.dom.d.ts for the Storage interface.

No functionality changes, just documentation update.