### PR TITLE
Change peer dependency to @ngrx/store v4 or v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "homepage": "https://github.com/btroncone/ngrx-store-localstorage#readme",
   "peerDependencies": {
-    "@ngrx/store": "^4.0.0"
+    "@ngrx/store": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@angular/core": "^2.4.7",
     "@ngrx/core": "^1.2.0",
-    "@ngrx/store": "^2.2.1",
+    "@ngrx/store": "^5.0.0",
     "@types/core-js": "^0.9.35",
     "@types/crypto-js": "^3.1.33",
     "@types/jasmine": "^2.5.47",


### PR DESCRIPTION
Allows using [@ngrx/store](https://github.com/ngrx/platform/) `^5.0.0` as peer dependency.

https://github.com/ngrx/platform/blob/v5.0.0/modules/store/CHANGELOG.md should not introduce any breaking changes related to the functionality.