### PR TITLE
Fixes #78 adds new syncCondition config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ An interface defining the configuration attributes to bootstrap `localStorageSyn
 * `removeOnUndefined` (optional) `boolean`: Specify if the state is removed from the storage when the new value is undefined, this will default to `false`.
 * `storageKeySerializer` (optional) `(key: string) => string`: Сustom serialize function for storage keys, used to avoid Storage conflicts. 
 * `restoreDates` \(*boolean? = true*): Restore serialized date objects. If you work directly with ISO date strings, set this option to `false`.
+* `syncCondition` (optional) `(state) => boolean`: When set, sync to storage medium will only occur when this function returns a true boolean. Example: `(state) => state.config.syncToStorage` will check the state tree under config.syncToStorage and if true, it will sync to the storage. If undefined or false it will not sync to storage. Often useful for "remember me" options in login.
 Usage: `localStorageSync({keys: ['todos', 'visibilityFilter'], storageKeySerializer: (key) => 'cool_' + key, ... })`. In this example `Storage` will use keys `cool_todos` and `cool_visibilityFilter` keys to store `todos` and `visibilityFilter` slices of state). The key itself is used by default - `(key) => key`.
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,22 @@ export const syncStateUpdate = (
   keys: any[],
   storage: Storage,
   storageKeySerializer: (key: string) => string,
-  removeOnUndefined: boolean
+  removeOnUndefined: boolean,
+  syncCondition?: (state: any) => any
 ) => {
+  if (syncCondition) {
+    try {
+      if (syncCondition(state) !== true) {
+        return;
+      }
+    } catch (e) {
+      // Treat TypeError as do not sync
+      if (e instanceof TypeError) {
+        return;
+      }
+      throw e;
+    }
+  }
   keys.forEach(key => {
     let stateSlice = state[key];
     let replacer = undefined;
@@ -236,7 +250,8 @@ export const localStorageSync = (config: LocalStorageConfig) => (
       stateKeys,
       config.storage,
       config.storageKeySerializer,
-      config.removeOnUndefined
+      config.removeOnUndefined,
+      config.syncCondition
     );
     return nextState;
   };
@@ -271,4 +286,5 @@ export interface LocalStorageConfig {
   removeOnUndefined?: boolean;
   restoreDates?: boolean;
   storageKeySerializer?: (key: string) => string;
+  syncCondition?: (state: any) => any;
 }


### PR DESCRIPTION
I decided to go with passing a function (state) => boolean. That should make it more flexible and in line with common ngrx patterns of using selectors.