### PR TITLE
Add support for merging intitial state into rehydrated state

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "peerDependencies": {
     "@ngrx/store": "^4.0.0 || ^5.0.0"
   },
+  "dependencies": {
+    "deepmerge": "^2.1.0"
+  },
   "devDependencies": {
     "@angular/core": "^2.4.7",
     "@ngrx/core": "^1.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import merge from 'deepmerge';
+import * as merge from 'deepmerge';
 
 const INIT_ACTION = '@ngrx/store/init';
 const UPDATE_ACTION = '@ngrx/store/update-reducers';
@@ -230,12 +230,8 @@ export const localStorageSync = (config: LocalStorageConfig) => (
          Handle case where state is rehydrated AND initial state is supplied.
          Any additional state supplied will override rehydrated state for the given key.
          */
-    if (
-      (action.type === INIT_ACTION || action.type === UPDATE_ACTION) &&
-      rehydratedState
-    ) {
-      state = merge.all([state, config.initialState || {}, rehydratedState]);
-    }
+    state = mergeInitialState(state, config.initialState, rehydratedState, action);
+
     const nextState = reducer(state, action);
     syncStateUpdate(
       nextState,
@@ -247,6 +243,16 @@ export const localStorageSync = (config: LocalStorageConfig) => (
     return nextState;
   };
 };
+
+export const mergeInitialState = (state, initialState, rehydratedState, action) => {
+  if (
+    (action.type === INIT_ACTION || action.type === UPDATE_ACTION) &&
+    rehydratedState
+  ) {
+    return merge.all([state, initialState || {}, rehydratedState]);
+  }
+  return state;
+}
 
 /*
     @deprecated: Use localStorageSync(LocalStorageConfig)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import merge from 'deepmerge';
+
 const INIT_ACTION = '@ngrx/store/init';
 const UPDATE_ACTION = '@ngrx/store/update-reducers';
 const detectDate = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
@@ -232,7 +234,7 @@ export const localStorageSync = (config: LocalStorageConfig) => (
       (action.type === INIT_ACTION || action.type === UPDATE_ACTION) &&
       rehydratedState
     ) {
-      state = Object.assign({}, state, rehydratedState);
+      state = merge.all([state, config.initialState || {}, rehydratedState]);
     }
     const nextState = reducer(state, action);
     syncStateUpdate(
@@ -272,6 +274,7 @@ export interface LocalStorageConfig {
   keys: any[];
   rehydrate?: boolean;
   storage?: Storage;
+  initialState?: any;
   removeOnUndefined?: boolean;
   restoreDates?: boolean;
   storageKeySerializer?: (key: string) => string;


### PR DESCRIPTION
This is an attempt at solving #80, by allowing users to supply an `initialState` object to the metareducer

First commit provides the basic behavior
second commit extracts into a separate method & includes a test