### PR TITLE
Null is an object!

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export const rehydrateApplicationState = (
       const isObjectRegex = new RegExp('{|\\[');
       let raw = stateSlice;
 
-      if (isObjectRegex.test(stateSlice.charAt(0)) || stateSlice === 'null') {
+      if (stateSlice === 'null' || isObjectRegex.test(stateSlice.charAt(0))) {
         raw = JSON.parse(stateSlice, reviver);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export const rehydrateApplicationState = (
       const isObjectRegex = new RegExp('{|\\[');
       let raw = stateSlice;
 
-      if (isObjectRegex.test(stateSlice.charAt(0))) {
+      if (isObjectRegex.test(stateSlice.charAt(0)) || stateSlice === 'null') {
         raw = JSON.parse(stateSlice, reviver);
       }
 


### PR DESCRIPTION
If a null is stored in a separate key/value it should be looked upon as a object, not a string.
Otherwise the null will become a string. you're not gonna have a good time :grinning: 
Fix suggested by @RubenVermeulen