### PR TITLE
Fix for peer dependency version mismatch warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-store-localstorage",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "State and local storage syncing for @ngrx/store",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/btroncone/ngrx-store-localstorage#readme",
   "peerDependencies": {
-    "@ngrx/store": "^4.0.0 || ^5.0.0"
+    "@ngrx/store": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@angular/core": "^2.4.7",


### PR DESCRIPTION
According to #90 and my own experience, the only issue is peer dependency warning for ngrx/store, which is already on v6.0.0.

<img width="1250" alt="screen shot 2018-06-12 at 22 24 07" src="https://user-images.githubusercontent.com/645678/41312431-b813d6b6-6e8f-11e8-8627-1043a20cd45a.png">

I wasn't sure if this package should be on par with ngrx and Angular major versions, so bumped just patch version, and hope that's right.