### PR TITLE
Merge initial and rehydrated states

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@angular/core": "^2.4.7",
     "@ngrx/core": "^1.2.0",
-    "@ngrx/store": "^5.0.0",
+    "@ngrx/store": "^7.0.0",
     "@types/core-js": "^0.9.35",
     "@types/crypto-js": "^3.1.33",
     "@types/jasmine": "^2.5.47",
@@ -47,6 +47,7 @@
     "es6-shim": "^0.35.0",
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
+    "localstorage-polyfill": "^1.0.1",
     "rimraf": "^2.5.4",
     "rxjs": "^5.1.1",
     "tslint": "^4.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,20 @@ export const localStorageSync = (config: LocalStorageConfig) => (
       (action.type === INIT_ACTION || action.type === UPDATE_ACTION) &&
       rehydratedState
     ) {
-      state = Object.assign({}, state, rehydratedState);
+      if (state) {
+        Object.keys(state).forEach(function (key) {
+          if (state[key] instanceof Array && rehydratedState[key] instanceof Array) {
+              state[key] = rehydratedState[key];
+          } else if (typeof state[key] === 'object'
+              && typeof rehydratedState[key] === 'object') {
+              state[key] = Object.assign({}, state[key], rehydratedState[key]);
+          } else {
+              state[key] = rehydratedState[key];
+          }
+        });
+      } else {
+        state = Object.assign({}, state, rehydratedState);
+      }
     }
     const nextState = reducer(state, action);
     syncStateUpdate(


### PR DESCRIPTION
Replaces https://github.com/btroncone/ngrx-store-localstorage/pull/15

# What does this solve?

It's common for state schemas to change throughout time. For example

```
{
  state: {
    foo: string;
  }
}
```

may become

```
{
  state: {
    bar: string;
  }
}
```

Doing so with rehydrate enabled can break an application. Our new initial state may contain just bar. However the redyrated state contains foo instead. A selector may expect bar to exist and errors when it does not.

# How does it solve it

Instead of using just the deserialized state from localstorage, merge it with initial state. Thanks to qvantor for a solution to that. However qvantor's pull request did not contain any unit test and the issue is rather murky on what exactly is the problem. The intent of this pull request is to clear up exactly what the problem is and my suggested fix with proof that it effectively solves the problem.

# Things to review

- I've introduced localstorage-polyfill as a dev dependency. This allows the test to run in a node environment instead of a browser.
- Most current tests use MockStorage and mockStorageKeySerializer. However these do not run the area of code I wanted to test. I created more of an integration test that actually reads and writes to localstorage and sets up a reducer with metareducer.
- This fix is always enabled. I can't think of any reason why someone wouldn't want this enabled so I did not make any configuration setting to enable/disable.

I would not like to merge my own pull request. So hopefully someone can review and merge. I think this makes the project easier to use. I've been using qvantor's solution manually patched for months and have not run into any trouble with it.