### PR TITLE
update-reducers fix

### DIFF
--- a/spec/index_spec.ts
+++ b/spec/index_spec.ts
@@ -4,6 +4,7 @@ import { syncStateUpdate, rehydrateApplicationState, dateReviver, localStorageSy
 import *  as CryptoJS from 'crypto-js';
 import 'localstorage-polyfill';
 const INIT_ACTION = '@ngrx/store/init';
+const UPDATE_ACTION = '@ngrx/store/update-reducers';
 
 // Very simple classes to test serialization options.  They cover string, number, date, and nested classes
 // The top level class has static functions to help test reviver, replacer, serialize and deserialize
@@ -485,5 +486,26 @@ describe('ngrxLocalStorage', () => {
           feature1: { slice11: true, slice12: [1, 2], slice13: {} },
           feature2: { slice21: true, slice22: [1, 2], slice23: {} },
         });
+    });
+
+   it('should not merge with rehydrated state after reducers are updated', () => {
+        const initialToken = 'initial token';
+        const newToken = 'new token';
+
+        localStorage.setItem('token', initialToken);
+
+        const reducer = (state = {}, action) => state;
+        const metaReducer = localStorageSync({keys: ['token'], rehydrate: true});
+        const action = {type: INIT_ACTION};
+
+        const tempState = metaReducer(reducer)({}, action);
+
+        expect(localStorage.getItem('token')).toEqual(initialToken);
+        expect(tempState.token).toEqual(initialToken);
+
+        const updateAction = {type: UPDATE_ACTION};
+        const finalState = metaReducer(reducer)({ token: newToken }, updateAction);
+        expect(localStorage.getItem('token')).toEqual(newToken);
+        expect(finalState.token).toEqual(newToken);
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import * as merge from 'lodash.merge';
 
 const INIT_ACTION = '@ngrx/store/init';
-const UPDATE_ACTION = '@ngrx/store/update-reducers';
 const detectDate = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
 // correctly parse dates from local storage
@@ -250,7 +249,7 @@ export const localStorageSync = (config: LocalStorageConfig) => (
       nextState = { ...state };
     }
 
-    if ((action.type === INIT_ACTION || action.type === UPDATE_ACTION) && rehydratedState) {
+    if (action.type === INIT_ACTION && rehydratedState) {
       nextState = merge({}, nextState, rehydratedState);
     }
 


### PR DESCRIPTION
fix issue overwriting values with old values from rehydrated state, when reducers are updated.

Not sure if the test is needed, because update action is deleted.