### PR TITLE
Try replacing lodash with deepmerge

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "typings": "./dist/index.d.ts",
   "dependencies": {
-    "lodash.merge": "^4.6.1"
+    "deepmerge": "^3.2.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as merge from 'lodash.merge';
+import * as deepmerge from 'deepmerge';
 
 const INIT_ACTION = '@ngrx/store/init';
 const UPDATE_ACTION = '@ngrx/store/update-reducers';
@@ -251,7 +251,11 @@ export const localStorageSync = (config: LocalStorageConfig) => (
     }
 
     if ((action.type === INIT_ACTION || action.type === UPDATE_ACTION) && rehydratedState) {
-      nextState = merge({}, nextState, rehydratedState);
+      const overwriteMerge = (destinationArray, sourceArray, options) => sourceArray;
+      const options: deepmerge.Options = {
+        arrayMerge: overwriteMerge
+      };
+      nextState = deepmerge(nextState, rehydratedState, options);
     }
 
     nextState = reducer(nextState, action);


### PR DESCRIPTION
Alternative fix for #123

This change gets the project on a better maintained package. lodash.merge is no longer maintained and suffers from a potential security vulnerability. lodash itself would increase the bundle size to an unacceptable level. Switching to deepmerge actually reduces the webpack bundle size by about 10k compared to lodash.merge.

Previously it was decided to avoid deepmerge due to observed issues when used with the project vuex-persist. This seems only to be unwanted array concatenation instead of replacement. It's easy to avoid this using options set to deepmerge, which this PR demonstrates.

Still this is a significant change and we cannot guarantee the behaviour will exactly match lodash.merge. If we decide to go with deepmerge, I recommend releasing a beta release and asking users to try this out before declaring it stable.