### PR TITLE
Remove deprecated `localStorageSyncAndClean`, v9 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Remove deprecated `localStorageSyncAndClean` function
 
+### Features
+
+- Allow `@ngrx/store` v9 as a peer dependency [#142](https://github.com/btroncone/ngrx-store-localstorage/pull/142)
+- Add `mergeReducer` option to define the reducer to use to merge the rehydrated state from storage with the state from the ngrx store [#135](https://github.com/btroncone/ngrx-store-localstorage/pull/135)
+
 ## 8.0.0
 
 ### Potentially breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 9.0.0
+
+### Breaking changes
+
+- Remove deprecated `localStorageSyncAndClean` function
+
 ## 8.0.0
 
 ### Potentially breaking changes

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # ngrx-store-localstorage
+
 Simple syncing between ngrx store and local storage.
 
 ## Dependencies
+
 `ngrx-store-localstorage` depends on [@ngrx/store](https://github.com/ngrx/store) and [Angular 2+](https://github.com/angular/angular).
 
 ## Usage
+
 ```bash
 npm install ngrx-store-localstorage --save
 ```
-**UPDATE FOR NGRX 4**
 
 1. Wrap localStorageSync in an exported function.
 2. Include in your meta-reducers array in `StoreModule.forRoot`.
+
 ```ts
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
@@ -40,13 +43,17 @@ export class MyAppModule {}
 ```
 
 ## API
+
 ### `localStorageSync(config: LocalStorageConfig): Reducer`
+
 Provide state (reducer) keys to sync with local storage. *Returns a meta-reducer*.
 
 #### Arguments
+
 * `config` An object that matches with the `LocalStorageConfig` interface, `keys` is the only required property.
 
 ### **LocalStorageConfig**
+
 An interface defining the configuration attributes to bootstrap `localStorageSync`. The following are properties which compose `LocalStorageConfig`:
 * `keys` (required) State keys to sync with local storage. The keys can be defined in two different formats:
     * `string[]`: Array of strings representing the state (reducer) keys. Full state will be synced (e.g. `localStorageSync({keys: ['todos']})`).
@@ -87,37 +94,3 @@ An interface defining the configuration attributes to bootstrap `localStorageSyn
 * `mergeReducer` (optional) `(state: any, rehydratedState: any, action: any) => any`: Defines the reducer to use to merge the rehydrated state from storage with the state from the ngrx store. If unspecified, defaults to performing a full deepmerge on an `INIT_ACTION` or an `UPDATE_ACTION`.
 
 Usage: `localStorageSync({keys: ['todos', 'visibilityFilter'], storageKeySerializer: (key) => 'cool_' + key, ... })`. In this example `Storage` will use keys `cool_todos` and `cool_visibilityFilter` keys to store `todos` and `visibilityFilter` slices of state). The key itself is used by default - `(key) => key`.
-
----
-### ~~`localStorageSyncAndClean(keys: any[], rehydrate: boolean = false, removeOnUndefined: boolean = false): Reducer`~~
-**This function is deprecated and soon will be removed, please use _localStorageSync(LocalStorageConfig)_.**
-
-A shorthand that wraps the functionalities of `localStorageSync` and asumes `localStorage` as the storage.
-
-#### Arguments
-
-* `keys` State keys to sync with local storage. The keys can be defined in two different formats:
-    * \(*string[]*): Array of strings representing the state (reducer) keys. Full state will be synced (e.g. `localStorageSync(['todos'])`).
-
-    * \(*object[]*): Array of objects where for each object the key represents the state key and the value represents custom serialize/deserialize options. This can be one of the following:
-
-        * An array of properties which should be synced. This allows for the partial state sync (e.g. `localStorageSync([{todos: ['name', 'status'] }, ... ])`).
-
-        * A reviver function as specified in the [JSON.parse documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
-
-        * An object with properties that specify one or more of the following:
-
-            * serialize: A function that takes a state object and returns a plain json object to pass to json.stringify.
-
-            * deserialize: A function that takes that takes the raw JSON from JSON.parse and builds a state object.
-
-            * replacer: A replacer function as specified in the [JSON.stringify documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
-
-            * space: The space value to pass JSON.stringify.
-
-            * reviver: A reviver function as specified in the [JSON.parse documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
-
-            * filter: An array of properties which should be synced (same format as the stand-along array specified above).
-* `rehydrateState` \(*boolean? = false*): Pull initial state from local storage on startup.
-* `removeOnUndefined` \(*boolean? = false*): Specify if the state is removed from the storage when the new value is undefined.
-* `checkStorageAvailability` \(*boolean? = false*): Specify if the storage availability checking is expected, i.e. for server side rendering / Universal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-store-localstorage",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "State and local storage syncing for @ngrx/store",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,28 +300,6 @@ export const localStorageSync = (config: LocalStorageConfig) => (
   };
 };
 
-/*
-    @deprecated: Use localStorageSync(LocalStorageConfig)
-
-    Wraps localStorageSync functionality acepting the removeOnUndefined boolean parameter in order
-    to clean/remove the state from the browser on situations like state reset or logout.
-    Defines localStorage as default storage.
-*/
-export const localStorageSyncAndClean = (
-  keys: any[],
-  rehydrate: boolean = false,
-  removeOnUndefined: boolean = false
-) => (reducer: any) => {
-  let config: LocalStorageConfig = {
-    keys: keys,
-    rehydrate: rehydrate,
-    storage: localStorage,
-    removeOnUndefined: removeOnUndefined
-  };
-
-  return this.localStorageSync(config);
-};
-
 export interface LocalStorageConfig {
   keys: any[];
   rehydrate?: boolean;


### PR DESCRIPTION
- feat: remove deprecated localStorageSyncAndClean function
- update changelog and bump to version 9.0.0

Changelog updated for #142 and #135.