### PR TITLE
ci: manually add github ssh keys to known_hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
+      - run: mkdir -p ~/.ssh
+      - run: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:
           name: Run semantic-release
           command: cd dist/lib && ../../node_modules/.bin/semantic-release


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/btroncone/ngrx-store-localstorage/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #192


## What is the new behavior?

Manually add github ssh keys to the `known_hosts` file before running semantic release


## Other information

Based on the Circle CI docs: https://circleci.com/docs/2.0/gh-bb-integration/#establishing-the-authenticity-of-an-ssh-host