### PR TITLE
fix: removeOnUndefined option using Angular Universal

### DIFF
--- a/projects/lib/src/lib/index.ts
+++ b/projects/lib/src/lib/index.ts
@@ -212,7 +212,7 @@ export const syncStateUpdate = (
             } catch (e) {
                 console.warn('Unable to save state to localStorage:', e);
             }
-        } else if (typeof stateSlice === 'undefined' && removeOnUndefined) {
+        } else if (typeof stateSlice === 'undefined' && removeOnUndefined && storage !== undefined) {
             try {
                 storage.removeItem(storageKeySerializer(key as string));
             } catch (e) {


### PR DESCRIPTION
Check if storage is undefined before using removeItem

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/btroncone/ngrx-store-localstorage/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Using Angular Universal and the removeOnUndefined option throws the error:

```
TypeError: Cannot read property 'removeItem' of undefined
```

## What is the new behavior?

Avoid error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information