### PR TITLE
fix: state initialization for feature stores

### DIFF
--- a/projects/lib/src/lib/index.ts
+++ b/projects/lib/src/lib/index.ts
@@ -269,7 +269,7 @@ export const localStorageSync = (config: LocalStorageConfig) => (reducer: any) =
 
         // If state arrives undefined, we need to let it through the supplied reducer
         // in order to get a complete state as defined by user
-        if (action.type === INIT_ACTION && !state) {
+        if ((action.type === INIT_ACTION || action.type === UPDATE_ACTION) && !state) {
             nextState = reducer(state, action);
         } else {
             nextState = { ...state };


### PR DESCRIPTION
Feature stores do not receive the @ngrx/store/init action, thus the initialization of the state skipped the merge

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/btroncone/ngrx-store-localstorage/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) <-- not sure this applies in this case


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

State is initialized and merged when receiving the @ngrx/store/init action, but in the case of feature stores the first action received is @ngrx/store/update-reducers.


## What is the new behavior?

State is now initialized and merged when receiving the @ngrx/store/init action or the @ngrx/store/update-reducers action.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information