### PR TITLE
refactor(dependency): migrate deepmerge to ts-deepmerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
                 "@angular/platform-browser-dynamic": "^16.0.1",
                 "@angular/router": "^16.0.1",
                 "@ngrx/store": "^16.0.0",
-                "deepmerge": "^4.2.2",
                 "rxjs": "~7.5.5",
+                "ts-deepmerge": "^6.2.0",
                 "tslib": "^2.3.0",
                 "zone.js": "~0.13.0"
             },
@@ -7432,6 +7432,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -19918,6 +19919,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ts-deepmerge": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.0.tgz",
+            "integrity": "sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==",
+            "engines": {
+                "node": ">=14.13.1"
+            }
+        },
         "node_modules/ts-node": {
             "version": "10.9.1",
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -26438,7 +26447,8 @@
         "deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true
         },
         "default-gateway": {
             "version": "6.0.3",
@@ -35821,6 +35831,11 @@
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
             "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
             "dev": true
+        },
+        "ts-deepmerge": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.2.0.tgz",
+            "integrity": "sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw=="
         },
         "ts-node": {
             "version": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
         "@angular/platform-browser-dynamic": "^16.0.1",
         "@angular/router": "^16.0.1",
         "@ngrx/store": "^16.0.0",
-        "deepmerge": "^4.2.2",
         "rxjs": "~7.5.5",
+        "ts-deepmerge": "^6.2.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.13.0"
     },

--- a/projects/lib/ng-package.json
+++ b/projects/lib/ng-package.json
@@ -5,6 +5,6 @@
     "entryFile": "src/public_api.ts"
   },
   "allowedNonPeerDependencies": [
-    "deepmerge"
+    "ts-deepmerge"
   ]
 }

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -25,7 +25,7 @@
         "@ngrx/store": "^16.0.0"
     },
     "dependencies": {
-        "deepmerge": "^4.2.2",
+        "ts-deepmerge": "^6.2.0",
         "tslib": "^2.3.0"
     }
 }

--- a/projects/lib/src/lib/index.ts
+++ b/projects/lib/src/lib/index.ts
@@ -1,4 +1,4 @@
-import deepmerge from 'deepmerge';
+import merge from 'ts-deepmerge';
 
 // Cannot import from the @ngrx/store package due to a module resolution issue.
 // See Issue #206.
@@ -226,12 +226,13 @@ export const syncStateUpdate = (
 // Default merge strategy is a full deep merge.
 export const defaultMergeReducer = (state: any, rehydratedState: any, action: any) => {
     if ((action.type === INIT_ACTION || action.type === UPDATE_ACTION) && rehydratedState) {
-        const overwriteMerge = (destinationArray: any, sourceArray: any, options: any) => sourceArray;
-        const options: deepmerge.Options = {
-            arrayMerge: overwriteMerge,
+        const options = {
+            allowUndefinedOverrides: false,
+            mergeArrays: true,
+            uniqueArrayItems: false
         };
 
-        state = deepmerge(state, rehydratedState, options);
+        state = merge.withOptions(options, state, rehydratedState);
     }
 
     return state;

--- a/spec/index_spec.ts
+++ b/spec/index_spec.ts
@@ -1,7 +1,7 @@
 declare var it, describe, expect;
 require('es6-shim');
 import * as CryptoJS from 'crypto-js';
-import deepmerge from 'deepmerge';
+import merge from 'ts-deepmerge';
 import 'localstorage-polyfill';
 import { dateReviver, localStorageSync, rehydrateApplicationState, syncStateUpdate } from '../projects/lib/src/public_api';
 
@@ -525,14 +525,14 @@ describe('ngrxLocalStorage', () => {
         const reducer = (state = initialState, action) => state;
         const mergeReducer = (state, rehydratedState, action) => {
             // Perform a merge where we only want a single property from feature1
-            // but a deepmerge with feature2
+            // but a merge with feature2
 
             return {
                 ...state,
                 feature1: {
                     slice11: rehydratedState.feature1.slice11,
                 },
-                feature2: deepmerge(state.feature2, rehydratedState.feature2),
+                feature2: merge(state.feature2, rehydratedState.feature2),
             };
         };
         const metaReducer = localStorageSync({


### PR DESCRIPTION
Migrated the deepmerge library to ts-deepmerge for better TypeScript compatibility and enhanced type checking.

fixes #229

## Summary

This PR migrates from the deepmerge library to ts-deepmerge, addressing an optimization warning in Angular 14 and later versions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X ] The commit message follows [our guidelines](https://github.com/btroncone/ngrx-store-localstorage/blob/master/CONTRIBUTING.md#commit):
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `X`. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Current Behavior

When integrating ngrx-store-localstorage with Angular 14 and later versions, a warning related to the deepmerge dependency emerges due to its CommonJS or AMD nature. This warning indicates potential optimization bailouts.

Issue Number: #229


## New Behavior

The ngrx-store-localstorage library no longer relies on deepmerge. Instead, it uses ts-deepmerge, eliminating the aforementioned Angular warning and ensuring better type safety.

## Breaking Change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This change not only resolves the current issue but also aligns the library closer to modern JS standards, making it more future-proof.
