### PR TITLE
refactor(dependency): migrate @bundled-es-modules/deepmerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
                 "@angular/platform-browser": "^16.0.1",
                 "@angular/platform-browser-dynamic": "^16.0.1",
                 "@angular/router": "^16.0.1",
+                "@bundled-es-modules/deepmerge": "^4.3.1",
                 "@ngrx/store": "^16.0.0",
-                "deepmerge": "^4.2.2",
                 "rxjs": "~7.5.5",
                 "tslib": "^2.3.0",
                 "zone.js": "~0.13.0"
@@ -2325,6 +2325,14 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bundled-es-modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==",
+            "dependencies": {
+                "deepmerge": "^4.3.1"
             }
         },
         "node_modules/@colors/colors": {
@@ -22721,6 +22729,14 @@
                 "@babel/helper-string-parser": "^7.21.5",
                 "@babel/helper-validator-identifier": "^7.19.1",
                 "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@bundled-es-modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==",
+            "requires": {
+                "deepmerge": "^4.3.1"
             }
         },
         "@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         "@angular/platform-browser": "^16.0.1",
         "@angular/platform-browser-dynamic": "^16.0.1",
         "@angular/router": "^16.0.1",
+        "@bundled-es-modules/deepmerge": "^4.3.1",
         "@ngrx/store": "^16.0.0",
-        "deepmerge": "^4.2.2",
         "rxjs": "~7.5.5",
         "tslib": "^2.3.0",
         "zone.js": "~0.13.0"

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -25,7 +25,7 @@
         "@ngrx/store": "^16.0.0"
     },
     "dependencies": {
-        "deepmerge": "^4.2.2",
+        "@bundled-es-modules/deepmerge": "^4.3.1",
         "tslib": "^2.3.0"
     }
 }

--- a/projects/lib/src/lib/index.ts
+++ b/projects/lib/src/lib/index.ts
@@ -1,4 +1,4 @@
-import deepmerge from 'deepmerge';
+import deepmerge from '@bundled-es-modules/deepmerge';
 
 // Cannot import from the @ngrx/store package due to a module resolution issue.
 // See Issue #206.

--- a/spec/index_spec.ts
+++ b/spec/index_spec.ts
@@ -1,7 +1,7 @@
 declare var it, describe, expect;
 require('es6-shim');
 import * as CryptoJS from 'crypto-js';
-import deepmerge from 'deepmerge';
+import deepmerge from '@bundled-es-modules/deepmerge';
 import 'localstorage-polyfill';
 import { dateReviver, localStorageSync, rehydrateApplicationState, syncStateUpdate } from '../projects/lib/src/public_api';
 


### PR DESCRIPTION
Migrated the deepmerge library to @bundled-es-modules/deepmerge.

fixes #229

## Summary

This PR transitions from the deepmerge library to @bundled-es-modules/deepmerge, which is essentially the same library but exported as an ES module. This addresses the optimization warning observed with Angular 14 and subsequent versions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our guidelines](https://github.com/btroncone/ngrx-store-localstorage/blob/master/CONTRIBUTING.md#commit):
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Current Behavior

Using ngrx-store-localstorage with Angular 14 and later versions throws a warning related to the deepmerge dependency due to its CommonJS or AMD format. This warning indicates potential optimization bailouts.

Issue Number: #229


## New Behavior

By moving to the @bundled-es-modules/deepmerge library, the optimization warning is mitigated. Users also have the advantage of sticking to a familiar library but with an ES module export.

## Breaking Change?

- [ ] Yes
- [X] No

## Other information

The decision to shift to @bundled-es-modules/deepmerge was taken after assessing community feedback and aiming to maintain compatibility while embracing ES module standards.
