### PR TITLE
Revert date parse change, add start of line check to regex

### DIFF
--- a/projects/lib/src/lib/index.ts
+++ b/projects/lib/src/lib/index.ts
@@ -5,7 +5,7 @@ import deepmerge from "deepmerge";
 const INIT_ACTION = "@ngrx/store/init";
 const UPDATE_ACTION = "@ngrx/store/update-reducers";
 
-const detectDate = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
+const detectDate = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
 // correctly parse dates from local storage
 export const dateReviver = (_key: string, value: any) => {

--- a/projects/lib/src/lib/index.ts
+++ b/projects/lib/src/lib/index.ts
@@ -5,22 +5,14 @@ import deepmerge from "deepmerge";
 const INIT_ACTION = "@ngrx/store/init";
 const UPDATE_ACTION = "@ngrx/store/update-reducers";
 
-function dateOrDefault(dateString: string): Date | string {
-  const maybeDate = new Date(dateString);
-  if (maybeDate.toString() === "Invalid Date") {
-    return dateString;
-  } else {
-    return maybeDate;
-  }
-}
+const detectDate = /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
 // correctly parse dates from local storage
 export const dateReviver = (_key: string, value: any) => {
-  if (typeof value === "string") {
-    return dateOrDefault(value);
-  } else {
-    return value;
+  if (typeof value === "string" && detectDate.test(value)) {
+    return new Date(value);
   }
+  return value;
 };
 
 const dummyReviver = (_key: string, value: any) => value;

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -521,10 +521,10 @@ describe("ngrxLocalStorage", () => {
       anumber: 3.14159,
       aboolean: true,
     };
-    const initalState = { state: t1Simple };
+    const initialState = { state: t1Simple };
 
     syncStateUpdate({
-      state: initalState,
+      state: initialState,
       keys: ["state"],
       storage,
       storageKeySerializer,
@@ -538,7 +538,7 @@ describe("ngrxLocalStorage", () => {
       restoreDates: false,
     });
     expect(finalState).toEqual(
-      initalState,
+      initialState,
       "rehydrated state should equal initial state",
     );
   });
@@ -877,9 +877,20 @@ describe("ngrxLocalStorage", () => {
   });
 
   describe("dateReviver", () => {
-    it("should allow various valid date formats when parsing string", () => {
-      // given
-      const sampleDateTimes = [
+    it("should allow ISO date formats when parsing strings", () => {
+      const isoDateTimes = [
+        "2025-04-12T00:00:00", // ISO with time
+        "2025-04-12T00:00:00Z", // ISO UTC
+        "2025-04-12T00:00:00+02:00", // ISO with timezone
+      ];
+
+      isoDateTimes.forEach((dateStr) =>
+        expect(dateReviver(null, dateStr)).toEqual(new Date(dateStr)),
+      );
+    });
+
+    it("should NOT allow other date formats when parsing string", () => {
+      const otherDateTimes = [
         "2025/04/15", // yyyy/mm/dd
         "2025-04-15", // yyyy-mm-dd (ISO 8601)
         "12/04/2025", // dd/mm/yyyy
@@ -895,44 +906,10 @@ describe("ngrxLocalStorage", () => {
         "2025-April-15", // verbose ISO
         "Tuesday, April 15, 2025", // full day name
         "Tue, 15 Apr 2025", // RFC 2822 format
-        "2025-04-12T00:00:00", // ISO with time
-        "2025-04-12T00:00:00Z", // ISO UTC
-        "2025-04-12T00:00:00+02:00", // ISO with timezone
       ];
 
-      // then
-      sampleDateTimes.forEach((date) =>
-        expect(dateReviver(null, date)).toEqual(new Date(date)),
-      );
-    });
-
-    it("should disallow various invalid date formats when parsing string", () => {
-      // given
-      const sampleDateTimes = [
-        "2025fdsa/04/15", // yyyy/mm/dd
-        "2025fdsa-04-15", // yyyy-mm-dd (ISO 8601)
-        "12fdsa/04/2025", // dd/mm/yyyy
-        "12fdsa-04-2025", // dd-mm-yyyy
-        "04fdsa/15/2025", // mm/dd/yyyy (US)
-        "04fdsa-15-2025", // mm-dd-yyyy (US)
-        "Apr fdsa15, 2025", // short month format
-        "15 Apr fdsa2025", // day short month year
-        "April fdsa15, 2025", // full month format
-        "15 April fdsa2025", // day full month year
-        "2025.fdsa04.15", // dot-separated
-        "2025-Apr-1fdsa5", // ISO variation
-        "2025-Afdsailpr-15", // verbose ISO
-        "Tuesday, fdsaApril 15, 2025", // full day name
-        "Tue, 15 Apr fdsa2025", // RFC 2822 format
-        "2025-04-12Tfdsa00:00:00", // ISO with time
-        "2025-04-12Tfdsa00:00:00Z", // ISO UTC
-        "2025-04-fdsa12T00:00:00+02:00", // ISO with timezone
-        '{ "nestedDate": "2025-04-12T00:00:00Z" }', // nested json date
-      ];
-
-      // then
-      sampleDateTimes.forEach((date) =>
-        expect(dateReviver(null, date)).toEqual(date),
+      otherDateTimes.forEach((dateStr) =>
+        expect(dateReviver(null, dateStr)).toEqual(dateStr),
       );
     });
   });

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -906,6 +906,7 @@ describe("ngrxLocalStorage", () => {
         "2025-April-15", // verbose ISO
         "Tuesday, April 15, 2025", // full day name
         "Tue, 15 Apr 2025", // RFC 2822 format
+        '{ "nestedDate": "2025-04-12T00:00:00Z" }', // nested json date
       ];
 
       otherDateTimes.forEach((dateStr) =>


### PR DESCRIPTION
## Summary

- Reverts the date parsing changes from #274
- Adds start of line check to date reviver regex to fix #138

## Reasoning

1. This library has been around for a long time now. I think it's important to minimize changes that may cause applications to break unexpectedly. Even though there is #282 to fix the number parsing issue specifically, I think it's better to just revert to the previous ISO date format regex detection to be on the safe side.
2. If someone wants custom date reviver behavior they can use the `reviver` config to achieve that.
3. The default `JSON.stringify()` behavior creates an [ISO string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON) which this implementation handles
4. A similar change to use `Date.parse()` was introduced way back in 2017 in #51, and then reverted in [0507f9d](https://github.com/btroncone/ngrx-store-localstorage/commit/0507f9d80c237ff9a52e90ca53f29500be7d63d9) because of the same number issue #54

## Issues

- Fixes #275
- Fixes #138
